### PR TITLE
Allow custom URL for the used GPT API

### DIFF
--- a/scripts/gpt-api.js
+++ b/scripts/gpt-api.js
@@ -6,7 +6,8 @@ async function callGptApi(query) {
 	const apiKey = game.settings.get(moduleName, 'apiKey');
 	const model = game.settings.get(moduleName, 'modelVersion');
 	const prompt = getGamePromptSetting();
-	const apiUrl = 'https://api.openai.com/v1/chat/completions';
+	const service = game.settings.get(moduleName, 'useCustomGPT') ? game.settings.get(moduleName, 'customGPTUrl') : 'https://api.openai.com' 
+	const apiUrl = service + '/v1/chat/completions';
 	const promptMessage = {role: 'user', content: prompt};
 	const queryMessage = {role: 'user', content: query};
 	const messages = pushHistory().concat(promptMessage, queryMessage);

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -25,7 +25,24 @@ export const gameSystems = (() => {
 
 export const registerSettings = () => {
 	// 'world' scope settings are available only to GMs
+	game.settings.register(moduleName, 'useCustomGPT', {
+		name: 'User a custom/self-hosted GPT model',
+		hint: 'Has to be compatible with OpenAI API. If enabled, the API key and model version settings will be ignored.',
+		scope: 'world',
+		config: true,
+		type: Boolean,
+		default: false,
+	});
 
+	game.settings.register(moduleName, 'customGPTUrl', {
+		name: 'Custom GPT model URL',
+		hint: 'URL of the custom GPT model. Has to be compatible with OpenAI API.',
+		scope: 'world',
+		config: true,
+		type: String,
+		default: 'http://localhost:1234',
+	});
+	
 	game.settings.register(moduleName, 'apiKey', {
 		name: 'OpenAI API key',
 		hint: 'API key for ChatGPT from OpenAI. Get yours at https://platform.openai.com/account/api-keys .',

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -26,7 +26,7 @@ export const gameSystems = (() => {
 export const registerSettings = () => {
 	// 'world' scope settings are available only to GMs
 	game.settings.register(moduleName, 'useCustomGPT', {
-		name: 'User a custom/self-hosted GPT model',
+		name: 'Use a custom/self-hosted GPT model',
 		hint: 'Has to be compatible with OpenAI API. If enabled, the API key and model version settings will be ignored.',
 		scope: 'world',
 		config: true,


### PR DESCRIPTION
This add a boolean and a string setting to the module.

The boolean would determine if a custom URL is to be used.
If so the string from that custom URL is used instead of the OpenAI api.

This makes the module usable with e.g. LM Studio.